### PR TITLE
add UI testing workflow with Maestro

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -89,3 +89,25 @@ jobs:
         with:
           name: apk
           path: build/app/outputs/flutter-apk/app-debug.apk
+
+  ui-tests:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: apk
+          path: ./
+
+      - name: Run UI Tests with Maestro
+        uses: theolm/maestro-run@v0.3.1-alpha
+        with:
+          apk-path: './app-debug.apk'
+          test-path: './maestro'
+          report-name: 'e-nakes-ui-test-report'
+          record: 'true'


### PR DESCRIPTION
This pull request adds a new UI testing workflow to the GitHub Actions configuration, enabling automated UI tests to run on the generated APK using Maestro after the build completes.

**Continuous Integration enhancements:**

* Added a new `ui-tests` job to `.github/workflows/flutter_ci.yml` that runs after the build, downloads the APK artifact, and executes UI tests using the Maestro tool, generating a test report.